### PR TITLE
updated to python3.10

### DIFF
--- a/templates/copy-zips.template.yaml
+++ b/templates/copy-zips.template.yaml
@@ -121,7 +121,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.10
       Role: !If [DeployIam, !GetAtt CopyRole.Arn, !Ref IamRoleArn]
       Timeout: 240
       Code:


### PR DESCRIPTION
Updating Python3.10 as Python3.8 is set to depricate in Oct 2024. 